### PR TITLE
add license header to *.go

### DIFF
--- a/benchmark_test.go
+++ b/benchmark_test.go
@@ -1,3 +1,7 @@
+// Copyright (c) 2019 Andreas Auernhammer. All rights reserved.
+// Use of this source code is governed by a license that can be
+// found in the LICENSE file.
+
 package sio
 
 import (

--- a/examples_test.go
+++ b/examples_test.go
@@ -1,3 +1,7 @@
+// Copyright (c) 2019 Andreas Auernhammer. All rights reserved.
+// Use of this source code is governed by a license that can be
+// found in the LICENSE file.
+
 package sio_test
 
 import (

--- a/helper_test.go
+++ b/helper_test.go
@@ -1,3 +1,7 @@
+// Copyright (c) 2019 Andreas Auernhammer. All rights reserved.
+// Use of this source code is governed by a license that can be
+// found in the LICENSE file.
+
 package sio
 
 import (

--- a/reader.go
+++ b/reader.go
@@ -1,3 +1,7 @@
+// Copyright (c) 2019 Andreas Auernhammer. All rights reserved.
+// Use of this source code is governed by a license that can be
+// found in the LICENSE file.
+
 package sio
 
 import (

--- a/reader_test.go
+++ b/reader_test.go
@@ -1,3 +1,7 @@
+// Copyright (c) 2019 Andreas Auernhammer. All rights reserved.
+// Use of this source code is governed by a license that can be
+// found in the LICENSE file.
+
 package sio
 
 import (

--- a/sio.go
+++ b/sio.go
@@ -1,3 +1,9 @@
+// Copyright (c) 2019 Andreas Auernhammer. All rights reserved.
+// Use of this source code is governed by a license that can be
+// found in the LICENSE file.
+
+// Package sio implements a provable secure authenticated encryption
+// scheme for continuous byte streams.
 package sio
 
 import (
@@ -72,7 +78,7 @@ func NewStream(cipher cipher.AEAD, bufSize int) *Stream {
 	}
 }
 
-// A Stream encrypts or decrypts continous byte streams.
+// A Stream encrypts or decrypts continuous byte streams.
 type Stream struct {
 	cipher  cipher.AEAD
 	bufSize int

--- a/writer.go
+++ b/writer.go
@@ -1,3 +1,7 @@
+// Copyright (c) 2019 Andreas Auernhammer. All rights reserved.
+// Use of this source code is governed by a license that can be
+// found in the LICENSE file.
+
 package sio
 
 import (

--- a/writer_test.go
+++ b/writer_test.go
@@ -1,3 +1,7 @@
+// Copyright (c) 2019 Andreas Auernhammer. All rights reserved.
+// Use of this source code is governed by a license that can be
+// found in the LICENSE file.
+
 package sio
 
 import (


### PR DESCRIPTION
This commit adds the license header to each
.go file. It also adds some package level
description.