### PR TITLE
add `sioutil` package

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,5 +19,5 @@ before_script:
 script:
     - diff -au <(gofmt -d .) <(printf "")
     - diff -au <(go vet .) <(printf "")
-    - go test
-    - go test -sio.BufSize=23 -sio.PlaintextSize=1825
+    - go test ./...
+    - go test -sio.BufSize=23 -sio.PlaintextSize=1825 ./...

--- a/sioutil/sio.go
+++ b/sioutil/sio.go
@@ -1,0 +1,22 @@
+// Copyright (c) 2019 Andreas Auernhammer. All rights reserved.
+// Use of this source code is governed by a license that can be
+// found in the LICENSE file.
+
+// Package sioutil implements some I/O utility functions.
+package sioutil
+
+import (
+	"io"
+)
+
+type nopCloser struct {
+	io.Writer
+}
+
+func (nopCloser) Close() error { return nil }
+
+// NopCloser returns a WriteCloser with a no-op Close method
+// wrapping the provided Writer w.
+func NopCloser(w io.Writer) io.WriteCloser {
+	return nopCloser{w}
+}


### PR DESCRIPTION
<!-- 
If you want to add a feature or fix a bug (not just typos / code style / ...),
please open an issue first such that we can discuss the feature and track bugs.
See: https://github.com/secure-io/sio-go/issues
Thank you :)
-->

#### What does the PR do?
This PR introduces the `sioutil` package.
It contains just a `NopCloser` method that is
related to https://golang.org/pkg/io/ioutil/#NopCloser.

It wraps a io.Writer and returns a io.WriteCloser that
does nothing on Close().
This is useful when en/decrypting an io.Writer but completing
the en/decryption process should not close the sink.

For example:
```
ew := s.EncryptWriter(sioutil.NopCloser(w), nonce, associatedData)
defer ew.Close() // This does not close 'w'.
```

#### What problem does it solve?
updates #7




<!-- Thank you very much for contributing to this project! -->
