### PR TITLE
make error vars constants 

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,17 +1,19 @@
 [![Godoc Reference](https://godoc.org/github.com/secure-io/sio-go?status.svg)](https://godoc.org/github.com/secure-io/sio-go)
 [![Build Status](https://travis-ci.org/secure-io/sio-go.svg?branch=master)](https://travis-ci.org/secure-io/sio-go)
 
-**The `sio` API is not stable yet and not meant for production use cases at the moment. We are working on a stable v1.0.0 release.**
-
 # Secure IO
 
 The `sio` package implements provable secure authenticated encryption for continuous byte streams.  
-It splits a data stream into `L` bytes long fragments and en/decrypts each fragment with an unqiue
+It splits a data stream into `L` bytes long fragments and en/decrypts each fragment with an unique
 key-nonce combination using an [AEAD](https://golang.org/pkg/crypto/cipher/#AEAD). For the last 
 fragment the construction prefixes the associated data with the `0x80` byte (instead of `0x00`)
 to prevent truncation attacks. 
 
 ![`sio` encryption scheme](https://github.com/secure-io/sio/blob/master/img/channel_construction.svg)
+
+The `sio` package follows semantic versioning and hasn't reached a stable v1.0.0, yet. So
+newer versions may cause major breaking API changes. However, we try to avoid such changes - if not really
+needed.
 
 ### How to use `sio`?
 

--- a/examples_test.go
+++ b/examples_test.go
@@ -115,7 +115,7 @@ func ExampleDecReader() {
 
 	// Reading from r returns the original plaintext (or an error).
 	if _, err := ioutil.ReadAll(r); err != nil {
-		if err == sio.ErrAuth {
+		if err == sio.NotAuthentic {
 			// Read data is not authentic -> ciphertext has been modified.
 			// TODO: error handling
 			panic(err)
@@ -149,7 +149,7 @@ func ExampleDecReaderAt() {
 
 	// Reading from section returns the original plaintext (or an error).
 	if _, err := ioutil.ReadAll(section); err != nil {
-		if err == sio.ErrAuth {
+		if err == sio.NotAuthentic {
 			// Read data is not authentic -> ciphertext has been modified.
 			// TODO: error handling
 			panic(err)
@@ -220,7 +220,7 @@ func ExampleDecWriter() {
 	w := stream.DecryptWriter(plaintext, nonce, associatedData)
 	defer func() {
 		if err := w.Close(); err != nil {
-			if err == sio.ErrAuth { // During Close() the DecWriter may detect unauthentic data -> decryption error.
+			if err == sio.NotAuthentic { // During Close() the DecWriter may detect unauthentic data -> decryption error.
 				panic(err) // TODO: error handling
 			}
 			panic(err) // TODO: error handling
@@ -233,7 +233,7 @@ func ExampleDecWriter() {
 	// the underlying io.Writer (i.e. the plaintext *bytes.Buffer) or
 	// returns an error.
 	if _, err := w.Write(ciphertext); err != nil {
-		if err == sio.ErrAuth {
+		if err == sio.NotAuthentic {
 			// Read data is not authentic -> ciphertext has been modified.
 			// TODO: error handling
 			panic(err)

--- a/reader.go
+++ b/reader.go
@@ -363,20 +363,20 @@ func (r *DecReader) readFragment(p []byte, firstReadOffset int) (int, error) {
 		if len(p) < r.bufSize {
 			r.plaintextBuffer, err = r.cipher.Open(r.buffer[:0], r.nonce, r.buffer[:ciphertextLen], r.associatedData)
 			if err != nil {
-				r.err = ErrAuth
+				r.err = NotAuthentic
 				return 0, r.err
 			}
 			r.offset = copy(p, r.plaintextBuffer)
 			return r.offset, nil
 		}
 		if _, err = r.cipher.Open(p[:0], r.nonce, r.buffer[:ciphertextLen], r.associatedData); err != nil {
-			r.err = ErrAuth
+			r.err = NotAuthentic
 			return 0, r.err
 		}
 		return r.bufSize, nil
 	case err == io.EOF:
 		if firstReadOffset+n < r.cipher.Overhead() {
-			r.err = ErrAuth
+			r.err = NotAuthentic
 			return 0, r.err
 		}
 		r.closed = true
@@ -384,14 +384,14 @@ func (r *DecReader) readFragment(p []byte, firstReadOffset int) (int, error) {
 		if len(p) < firstReadOffset+n-r.cipher.Overhead() {
 			r.plaintextBuffer, err = r.cipher.Open(r.buffer[:0], r.nonce, r.buffer[:firstReadOffset+n], r.associatedData)
 			if err != nil {
-				r.err = ErrAuth
+				r.err = NotAuthentic
 				return 0, r.err
 			}
 			r.offset = copy(p, r.plaintextBuffer)
 			return r.offset, nil
 		}
 		if _, err = r.cipher.Open(p[:0], r.nonce, r.buffer[:firstReadOffset+n], r.associatedData); err != nil {
-			r.err = ErrAuth
+			r.err = NotAuthentic
 			return 0, r.err
 
 		}

--- a/sio.go
+++ b/sio.go
@@ -21,37 +21,23 @@ const (
 	BufSize = 1 << 14
 )
 
-var (
-	// ErrAuth is returned when the decryption of a data stream fails.
-	// It indicates that the data is not authentic (e.g. malisously
-	// modified).
-	ErrAuth = errAuth{}
+const (
+	// NotAuthentic is returned when the decryption of a data stream fails.
+	// It indicates that the data is not authentic - e.g. malisously modified.
+	NotAuthentic errorType = "data is not authentic"
 
 	// ErrExceeded is returned when no more data can be encrypted /
 	// decrypted securely. It indicates that the data stream is too
 	// large to be encrypted / decrypted with a single key-nonce
 	// combination.
-	ErrExceeded = errExceeded{}
+	//
+	// For BufSize this will happen after processing ~64 TiB.
+	ErrExceeded errorType = "data limit exceeded"
 )
 
-// The following error type construction prevents assigning new values to
-// ErrAuth or ErrExceeded. In particular it prevents client code from doing
-// shady things like:
-//
-//   `sio.ErrAuth = nil` or `sio.ErrAuth = sio.ErrExceeded`
-//
-// In contrast you could write e.g. `io.EOF = nil` which will most likely break
-// any I/O code in horrible ways.
+type errorType string
 
-type errType struct{ _ int }
-
-type errAuth errType
-
-func (errAuth) Error() string { return "sio: authentication failed" }
-
-type errExceeded errType
-
-func (errExceeded) Error() string { return "sio: data limit exceeded" }
+func (e errorType) Error() string { return string(e) }
 
 // NewStream creates a new Stream that encrypts or decrypts data
 // streams with the cipher. If you don't have special requirements

--- a/writer.go
+++ b/writer.go
@@ -268,7 +268,7 @@ func (w *DecWriter) Write(p []byte) (n int, err error) {
 		}
 		plaintext, err := w.cipher.Open(w.buffer[:0], nonce, w.buffer, w.associatedData)
 		if err != nil {
-			w.err = ErrAuth
+			w.err = NotAuthentic
 			return n, w.err
 		}
 		if _, err = writeTo(w.w, plaintext); err != nil {
@@ -285,7 +285,7 @@ func (w *DecWriter) Write(p []byte) (n int, err error) {
 		}
 		plaintext, err := w.cipher.Open(w.buffer[:0], nonce, p[:ciphertextLen], w.associatedData)
 		if err != nil {
-			w.err = ErrAuth
+			w.err = NotAuthentic
 			return n, w.err
 		}
 		if _, err = writeTo(w.w, plaintext); err != nil {
@@ -327,7 +327,7 @@ func (w *DecWriter) WriteByte(b byte) error {
 	}
 	plaintext, err := w.cipher.Open(w.buffer[:0], nonce, w.buffer, w.associatedData)
 	if err != nil {
-		w.err = ErrAuth
+		w.err = NotAuthentic
 		return w.err
 	}
 	if _, err = writeTo(w.w, plaintext); err != nil {
@@ -355,7 +355,7 @@ func (w *DecWriter) Close() error {
 		binary.LittleEndian.PutUint32(w.nonce[w.cipher.NonceSize()-4:], w.seqNum)
 		plaintext, err := w.cipher.Open(w.buffer[:0], w.nonce, w.buffer[:w.offset], w.associatedData)
 		if err != nil {
-			w.err = ErrAuth
+			w.err = NotAuthentic
 			return w.err
 		}
 		if _, w.err = writeTo(w.w, plaintext); w.err != nil {
@@ -409,7 +409,7 @@ func (w *DecWriter) ReadFrom(r io.Reader) (int64, error) {
 	}
 	plaintext, err := w.cipher.Open(buffer[:0], nonce, buffer[:ciphertextLen], w.associatedData)
 	if err != nil {
-		w.err = ErrAuth
+		w.err = NotAuthentic
 		return n, w.err
 	}
 	if _, err = writeTo(w.w, plaintext); err != nil {
@@ -438,7 +438,7 @@ func (w *DecWriter) ReadFrom(r io.Reader) (int64, error) {
 		}
 		plaintext, err = w.cipher.Open(buffer[:0], nonce, buffer[:ciphertextLen], w.associatedData)
 		if err != nil {
-			w.err = ErrAuth
+			w.err = NotAuthentic
 			return n, w.err
 		}
 		if _, err = writeTo(w.w, plaintext); err != nil {


### PR DESCRIPTION
#### What does the PR do?
This commit makes the error variables (ErrAuth and ErrExceeded)
constants. In general, constants are "better" than 'effectively
immutable' variables since the compiler can do a better job during
optimisation (e.g. inlining, ...). It's also simpler since we can
use the `const` as a language construct and don't have to accomplish
something similar with a type construction.

Further, this commit renames the `ErrAuth` to `NotAuthentic` b/c that's
more explicit. Calling code while now read like this:
```
if _, err := io.ReadAll(decReader); err != nil {
   if err == sio.NotAuthentic {
      // error handling
   }
}
```

This is a major breaking API change:
   - changing the error types
   - `ErrAuth` -> `NotAuthentic`


#### What problem does it solve?
Make the error handling more readable and simplify the error definition.
