### PR TITLE
fix go version in fuzzbuzz.yaml

### DIFF
--- a/fuzzbuzz.yaml
+++ b/fuzzbuzz.yaml
@@ -2,7 +2,7 @@ base: ubuntu:16.04
 targets:
   - name: secure-io
     language: go
-    version: "1.13"
+    version: "1.11"
     harness:
       function: Fuzz
       # package defines where to import FuzzerEntrypoint from


### PR DESCRIPTION
<!-- 
If you want to add a feature or fix a bug (not just typos / code style / ...),
please open an issue first such that we can discuss the feature and track bugs.
See: https://github.com/secure-io/sio-go/issues
Thank you :)
-->

#### What does the PR do?
Fuzzbuzz seems to not support Go 1.13 (yet)?!
Therefore, switch back to Go 1.11.

#### What problem does it solve?
<!-- For features and (major) bug fixes link the issue here (e.g. #42) ->




<!-- Thank you very much for contributing to this project! -->
