### PR TITLE
fuzz: add more fuzzing functions

### DIFF
--- a/fuzzbuzz.yaml
+++ b/fuzzbuzz.yaml
@@ -4,7 +4,7 @@ targets:
     language: go
     version: "1.11"
     harness:
-      function: Fuzz
+      function: FuzzAll
       build_tags: gofuzz
       # package defines where to import FuzzerEntrypoint from
       package: github.com/secure-io/sio-go


### PR DESCRIPTION
<!-- 
If you want to add a feature or fix a bug (not just typos / code style / ...),
please open an issue first such that we can discuss the feature and track bugs.
See: https://github.com/secure-io/sio-go/issues
Thank you :)
-->

#### What does the PR do?
This commit adds more fuzzing functions for
reading and writing data. It also fuzzes now
AES-128-GCM and ChaCha20-Poly1305.

#### What problem does it solve?
Currently, the fuzz coverage is quite small.



<!-- Thank you very much for contributing to this project! -->
