### PR TITLE
docs: improve go docs of writer implementation

### DIFF
--- a/writer_test.go
+++ b/writer_test.go
@@ -99,16 +99,22 @@ func TestReadFrom(t *testing.T) {
 	if n, err := sw.ReadFrom(bytes.NewReader(data)); err != nil || n != int64(len(data)) {
 		t.Fatalf("ReadFrom failed: got %d - want %d err: %v", n, int64(len(data)), err)
 	}
-	if !sw.closed {
-		t.Fatal("EncWriter wasn't closed by ReadFrom")
+	if sw.closed {
+		t.Fatal("EncWriter has been closed by ReadFrom")
+	}
+	if err := sw.Close(); err != nil {
+		t.Fatalf("Close failed: err: %v", err)
 	}
 
 	ctLen := int64(ciphertext.Len())
 	if n, err := ow.ReadFrom(ciphertext); err != nil || n != ctLen {
 		t.Fatalf("ReadFrom failed: got %d - want %d err: %v", n, ctLen, err)
 	}
-	if !ow.closed {
-		t.Fatal("DecWriter wasn't closed by ReadFrom")
+	if ow.closed {
+		t.Fatal("DecWriter has been closed by ReadFrom")
+	}
+	if err := ow.Close(); err != nil {
+		t.Fatalf("Close failed: err: %v", err)
 	}
 
 	if p := plaintext.Bytes(); !bytes.Equal(p, data) {


### PR DESCRIPTION
<!-- 
If you want to add a feature or fix a bug (not just typos / code style / ...),
please open an issue first such that we can discuss the feature and track bugs.
See: https://github.com/secure-io/sio-go/issues
Thank you :)
-->

#### What does the PR do?
This commit improves the go documentation of the
`EncWriter` and `DecWriter` structs and the
`Write*` and `ReadFrom` implementations.

In general, the docs are now more expressive and explicit
about the invariants and error conditions.

Further, this commit makes the `ReadFrom` implementations
compliant to its specification. Before, `ReadFrom` closed
the `EncWriter` / `DecWriter`.

#### What problem does it solve?
<!-- For features and (major) bug fixes link the issue here (e.g. #42) ->




<!-- Thank you very much for contributing to this project! -->
