### PR TITLE
fuzz: add fuzzing for ReadByte and WriteByte

### DIFF
--- a/fuzzbuzz.yaml
+++ b/fuzzbuzz.yaml
@@ -1,6 +1,6 @@
 base: ubuntu:16.04
 targets:
-  - name: secure-io
+  - name: sio
     language: go
     version: "1.11"
     setup:


### PR DESCRIPTION

<!-- 
If you want to add a feature or fix a bug (not just typos / code style / ...),
please open an issue first such that we can discuss the feature and track bugs.
See: https://github.com/secure-io/sio-go/issues
Thank you :)
-->

#### What does the PR do?
This commit adds fuzzing for the `ReadByte`
and `WriteByte` implementations.

Now, fuzzing code also pre-allocates a somewhat
randomized buffer once instead of always using
the same buffer size.

#### What problem does it solve?
<!-- For features and (major) bug fixes link the issue here (e.g. #42) ->




<!-- Thank you very much for contributing to this project! -->
