### PR TITLE
fuzz: prefer longer inputs

### DIFF
--- a/fuzz.go
+++ b/fuzz.go
@@ -61,6 +61,8 @@ func init() {
 	wStream = NewStream(c20p1305, BufSize)
 }
 
+var maxDataLen int
+
 func FuzzAll(data []byte) int {
 	v := FuzzReader(data)
 	v += FuzzReadByte(data)
@@ -69,6 +71,11 @@ func FuzzAll(data []byte) int {
 	v += FuzzWrite(data)
 	v += FuzzWriteByte(data)
 	v += FuzzReadFrom(data)
+
+	if len(data) > maxDataLen { // Prefer longer inputs
+		maxDataLen = len(data)
+		v += 1
+	}
 	return v
 }
 


### PR DESCRIPTION
<!-- 
If you want to add a feature or fix a bug (not just typos / code style / ...),
please open an issue first such that we can discuss the feature and track bugs.
See: https://github.com/secure-io/sio-go/issues
Thank you :)
-->

#### What does the PR do?
In general, the fuzzer does minimizes test cases.
Therefore, the fuzzing code barely sees long inputs.
Consequently, we have to tell the fuzzer that we like
long input values.

#### What problem does it solve?
<!-- For features and (major) bug fixes link the issue here (e.g. #42) ->




<!-- Thank you very much for contributing to this project! -->
