### PR TITLE
add golang-ci linting to CI

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -1,17 +1,18 @@
 task:
    matrix:
-      - name: linux
+      - name: golang-ci
         container:
            image: golang:latest
   
    modules_cache:
        fingerprint_script: cat go.sum
        folder: $GOPATH/pkg/mod
-   check_script: 
-       - diff -au <(gofmt -d .) <(printf "")
-       - diff -au <(go vet .) <(printf "")
-   get_script:
-      - go get ./...
+   check_script:
+       - curl -sfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.20.0
+       - $(go env GOPATH)/bin/golangci-lint run --config ./.golangci.yml
+   build_script:
       - go build -tags gofuzz ./...
-   test_script: go test -tags gofuzz ./...
+   test_script: 
+      - go test -tags gofuzz ./...
+
      

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -30,6 +30,4 @@ jobs:
       env:
         GO111MODULE: on
       run: |
-        diff -au <(gofmt -d .) <(printf "")
-        diff -au <(go vet .) <(printf "")
-        go test -tags gofuzz ./...
+         go test -tags gofuzz ./...

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,29 @@
+linters-settings:
+  golint:
+    min-confidence: 0
+
+  misspell:
+    locale: US
+
+linters:
+  disable-all: true
+  enable:
+    - typecheck
+    - goimports
+    - misspell
+    - govet
+    - golint
+    - ineffassign
+    - gosimple
+    - deadcode
+    - unparam
+    - unused
+    - structcheck
+
+issues:
+  exclude-use-default: false
+  exclude:
+      - should have a package comment
+
+service:
+  golangci-lint-version: 1.20.0 # use the fixed version to not introduce new linters unexpectedly

--- a/examples_test.go
+++ b/examples_test.go
@@ -43,7 +43,7 @@ func ExampleNewStream_xChaCha20Poly1305() {
 	// Load your secret key from a safe place. You may reuse it for
 	// en/decrypting multiple data streams. (XChaCha20-Poly1305 nonce
 	// values are large enough to be chosen at random without risking
-	// to select a nonce twice - probability is negligable).
+	// to select a nonce twice - probability is negligible).
 	//
 	// Obviously don't use this example key for anything real.
 	// If you want to convert a passphrase to a key, use a suitable

--- a/fuzz.go
+++ b/fuzz.go
@@ -74,7 +74,7 @@ func FuzzAll(data []byte) int {
 
 	if len(data) > maxDataLen { // Prefer longer inputs
 		maxDataLen = len(data)
-		v += 1
+		v++
 	}
 	return v
 }

--- a/helper_test.go
+++ b/helper_test.go
@@ -52,5 +52,5 @@ func PlaintextSize() int {
 
 type devNull struct{}
 
-func (_ devNull) Read(p []byte) (int, error)  { return len(p), nil }
-func (_ devNull) Write(p []byte) (int, error) { return len(p), nil }
+func (devNull) Read(p []byte) (int, error)  { return len(p), nil }
+func (devNull) Write(p []byte) (int, error) { return len(p), nil }

--- a/sio.go
+++ b/sio.go
@@ -233,7 +233,7 @@ func (s *Stream) DecryptReader(r io.Reader, nonce, associatedData []byte) *DecRe
 	return dr
 }
 
-// DecryptReader returns a new DecReaderAt that wraps r and
+// DecryptReaderAt returns a new DecReaderAt that wraps r and
 // decrypts and verifies everything it reads from r.
 //
 // The nonce must be Stream.NonceSize() bytes long and


### PR DESCRIPTION
<!-- 
If you want to add a feature or fix a bug (not just typos / code style / ...),
please open an issue first such that we can discuss the feature and track bugs.
See: https://github.com/secure-io/sio-go/issues
Thank you :)
-->

#### What does the PR do?
This commit adds golang-ci for running
linters during Cirrus builds.

The linting is run just on Cirrus CI
since linting on one platform is sufficient.

#### What problem does it solve?
<!-- For features and (major) bug fixes link the issue here (e.g. #42) ->




<!-- Thank you very much for contributing to this project! -->
