### PR TITLE
replace type of negative-offset error

### DIFF
--- a/reader.go
+++ b/reader.go
@@ -7,7 +7,6 @@ package sio
 import (
 	"crypto/cipher"
 	"encoding/binary"
-	"errors"
 	"io"
 	"io/ioutil"
 	"math"
@@ -462,7 +461,7 @@ type DecReaderAt struct {
 // a misbehaving producer of encrypted data.
 func (r *DecReaderAt) ReadAt(p []byte, offset int64) (int, error) {
 	if offset < 0 {
-		return 0, errors.New("sio: DecReaderAt.ReadAt: offset is negative")
+		return 0, errorType("sio: DecReaderAt.ReadAt: offset is negative")
 	}
 
 	t := offset / int64(r.bufSize)


### PR DESCRIPTION


<!-- 
If you want to add a feature or fix a bug (not just typos / code style / ...),
please open an issue first such that we can discuss the feature and track bugs.
See: https://github.com/secure-io/sio-go/issues
Thank you :)
-->

#### What does the PR do?
This commit replaces the type of the
error returned by `ReadAt` when the offset
is negative.

#### What problem does it solve?
<!-- For features and (major) bug fixes link the issue here (e.g. #42) ->




<!-- Thank you very much for contributing to this project! -->
