### PR TITLE
make the algorithm type public API

### DIFF
--- a/benchmark_test.go
+++ b/benchmark_test.go
@@ -11,7 +11,7 @@ import (
 )
 
 func BenchmarkEncrypt(b *testing.B) {
-	s, err := AES_128_GCM.New(make([]byte, 16))
+	s, err := AES_128_GCM.Stream(make([]byte, 16))
 	if err != nil {
 		b.Fatalf("Failed to create Stream: %v", err)
 	}
@@ -43,7 +43,7 @@ func BenchmarkEncrypt(b *testing.B) {
 }
 
 func BenchmarkDecrypt(b *testing.B) {
-	s, err := AES_128_GCM.New(make([]byte, 16))
+	s, err := AES_128_GCM.Stream(make([]byte, 16))
 	if err != nil {
 		b.Fatalf("Failed to create Stream: %v", err)
 	}

--- a/examples_test.go
+++ b/examples_test.go
@@ -26,7 +26,7 @@ func ExampleNewStream_aES128GCM() {
 	// If you want to convert a passphrase to a key, use a suitable
 	// package like argon2 or scrypt.
 	key, _ := hex.DecodeString("4c4d737f2199f3ccb13d2c81dfe38eb8")
-	stream, err := sio.AES_128_GCM.New(key)
+	stream, err := sio.AES_128_GCM.Stream(key)
 	if err != nil {
 		panic(err) // TODO: error handling
 	}
@@ -68,7 +68,7 @@ func ExampleNewStream_aES256GCM() {
 	// If you want to convert a passphrase to a key, use a suitable
 	// package like argon2 or scrypt.
 	key, _ := hex.DecodeString("5b48c6945ae03a93ecc20e38305d2cbe4a177133d83bf4773f1f3be636e2cc4b")
-	stream, err := sio.AES_256_GCM.New(key)
+	stream, err := sio.AES_256_GCM.Stream(key)
 	if err != nil {
 		panic(err) // TODO: error handling
 	}
@@ -90,7 +90,7 @@ func ExampleNewStream_xChaCha20Poly1305() {
 	// package like argon2 or scrypt - or take a look at the sio/sioutil
 	// package.
 	key, _ := hex.DecodeString("f230e700c4f120b623b84ac26cbcb5ae926f44f36589e63745a46ae0ca47137d")
-	stream, err := sio.XChaCha20Poly1305.New(key)
+	stream, err := sio.XChaCha20Poly1305.Stream(key)
 	if err != nil {
 		panic(err) // TODO: error handling
 	}

--- a/helper_test.go
+++ b/helper_test.go
@@ -58,7 +58,7 @@ func loadTestVectors(filename string) []TestVector {
 	}
 
 	var vec []struct {
-		Algorithm      algorithm
+		Algorithm      Algorithm
 		BufSize        int
 		Key            string
 		Nonce          string

--- a/reader_test.go
+++ b/reader_test.go
@@ -13,7 +13,7 @@ import (
 
 func TestVectorRead(t *testing.T) {
 	for i, test := range TestVectors {
-		stream, err := test.Algorithm.newWithBufSize(test.Key, test.BufSize)
+		stream, err := test.Algorithm.streamWithBufSize(test.Key, test.BufSize)
 		if err != nil {
 			t.Fatalf("Test %d: Failed to create new Stream: %v", i, err)
 		}
@@ -49,7 +49,7 @@ func TestVectorReadByte(t *testing.T) {
 		ciphertext.Reset()
 		plaintext.Reset()
 
-		stream, err := test.Algorithm.newWithBufSize(test.Key, test.BufSize)
+		stream, err := test.Algorithm.streamWithBufSize(test.Key, test.BufSize)
 		if err != nil {
 			t.Fatalf("Test %d: Failed to create new Stream: %v", i, err)
 		}
@@ -81,7 +81,7 @@ func TestVectorWriteTo(t *testing.T) {
 		ciphertext.Reset()
 		plaintext.Reset()
 
-		stream, err := test.Algorithm.newWithBufSize(test.Key, test.BufSize)
+		stream, err := test.Algorithm.streamWithBufSize(test.Key, test.BufSize)
 		if err != nil {
 			t.Fatalf("Test %d: Failed to create new Stream: %v", i, err)
 		}
@@ -107,7 +107,7 @@ func TestVectorWriteTo(t *testing.T) {
 
 func TestVectorReadAt(t *testing.T) {
 	for i, test := range TestVectors {
-		stream, err := test.Algorithm.newWithBufSize(test.Key, test.BufSize)
+		stream, err := test.Algorithm.streamWithBufSize(test.Key, test.BufSize)
 		if err != nil {
 			t.Fatalf("Test %d: Failed to create new Stream: %v", i, err)
 		}
@@ -131,7 +131,7 @@ func TestVectorReadAtSection(t *testing.T) {
 	for i, test := range TestVectors {
 		plaintext.Reset()
 
-		stream, err := test.Algorithm.newWithBufSize(test.Key, test.BufSize)
+		stream, err := test.Algorithm.streamWithBufSize(test.Key, test.BufSize)
 		if err != nil {
 			t.Fatalf("Test %d: Failed to create new Stream: %v", i, err)
 		}
@@ -150,7 +150,7 @@ func TestVectorReadAtSection(t *testing.T) {
 
 func TestSimpleRead(t *testing.T) {
 	for i, test := range SimpleTests {
-		stream, err := test.Algorithm.newWithBufSize(test.Key, test.BufSize)
+		stream, err := test.Algorithm.streamWithBufSize(test.Key, test.BufSize)
 		if err != nil {
 			t.Fatalf("Test %d: Failed to create new Stream: %v", i, err)
 		}
@@ -182,7 +182,7 @@ func TestSimpleReadByte(t *testing.T) {
 		ciphertext.Reset()
 		plaintext.Reset()
 
-		stream, err := test.Algorithm.newWithBufSize(test.Key, test.BufSize)
+		stream, err := test.Algorithm.streamWithBufSize(test.Key, test.BufSize)
 		if err != nil {
 			t.Fatalf("Test %d: Failed to create new Stream: %v", i, err)
 		}
@@ -211,7 +211,7 @@ func TestSimpleWriteTo(t *testing.T) {
 		ciphertext.Reset()
 		plaintext.Reset()
 
-		stream, err := test.Algorithm.newWithBufSize(test.Key, test.BufSize)
+		stream, err := test.Algorithm.streamWithBufSize(test.Key, test.BufSize)
 		if err != nil {
 			t.Fatalf("Test %d: Failed to create new Stream: %v", i, err)
 		}
@@ -234,7 +234,7 @@ func TestSimpleWriteTo(t *testing.T) {
 
 func TestSimpleReadAt(t *testing.T) {
 	for i, test := range SimpleTests {
-		stream, err := test.Algorithm.newWithBufSize(test.Key, test.BufSize)
+		stream, err := test.Algorithm.streamWithBufSize(test.Key, test.BufSize)
 		if err != nil {
 			t.Fatalf("Test %d: Failed to create new Stream: %v", i, err)
 		}
@@ -266,7 +266,7 @@ func TestSimpleReadAtSection(t *testing.T) {
 		ciphertext.Reset()
 		plaintext.Reset()
 
-		stream, err := test.Algorithm.newWithBufSize(test.Key, test.BufSize)
+		stream, err := test.Algorithm.streamWithBufSize(test.Key, test.BufSize)
 		if err != nil {
 			t.Fatalf("Test %d: Failed to create new Stream: %v", i, err)
 		}

--- a/sio_test.go
+++ b/sio_test.go
@@ -9,7 +9,7 @@ import (
 )
 
 type TestVector struct {
-	Algorithm      algorithm
+	Algorithm      Algorithm
 	BufSize        int
 	Key            []byte
 	Nonce          []byte
@@ -21,7 +21,7 @@ type TestVector struct {
 var TestVectors []TestVector = loadTestVectors("./test_vectors.json")
 
 type SimpleTest struct {
-	Algorithm      algorithm
+	Algorithm      Algorithm
 	BufSize        int
 	Key            []byte
 	Nonce          []byte

--- a/writer_test.go
+++ b/writer_test.go
@@ -19,7 +19,7 @@ func TestVectorWrite(t *testing.T) {
 		ciphertext.Reset()
 		plaintext.Reset()
 
-		stream, err := test.Algorithm.newWithBufSize(test.Key, test.BufSize)
+		stream, err := test.Algorithm.streamWithBufSize(test.Key, test.BufSize)
 		if err != nil {
 			t.Fatalf("Test %d: Failed to create new Stream: %v", i, err)
 		}
@@ -56,7 +56,7 @@ func TestVectorWriteByte(t *testing.T) {
 		ciphertext.Reset()
 		plaintext.Reset()
 
-		stream, err := test.Algorithm.newWithBufSize(test.Key, test.BufSize)
+		stream, err := test.Algorithm.streamWithBufSize(test.Key, test.BufSize)
 		if err != nil {
 			t.Fatalf("Test %d: Failed to create new Stream: %v", i, err)
 		}
@@ -93,7 +93,7 @@ func TestVectorReadFrom(t *testing.T) {
 		ciphertext.Reset()
 		plaintext.Reset()
 
-		stream, err := test.Algorithm.newWithBufSize(test.Key, test.BufSize)
+		stream, err := test.Algorithm.streamWithBufSize(test.Key, test.BufSize)
 		if err != nil {
 			t.Fatalf("Test %d: Failed to create new Stream: %v", i, err)
 		}
@@ -130,7 +130,7 @@ func TestSimpleWrite(t *testing.T) {
 		ciphertext.Reset()
 		plaintext.Reset()
 
-		stream, err := test.Algorithm.newWithBufSize(test.Key, test.BufSize)
+		stream, err := test.Algorithm.streamWithBufSize(test.Key, test.BufSize)
 		if err != nil {
 			t.Fatalf("Test %d: Failed to create new Stream: %v", i, err)
 		}
@@ -165,7 +165,7 @@ func TestSimpleWriteByte(t *testing.T) {
 		ciphertext.Reset()
 		plaintext.Reset()
 
-		stream, err := test.Algorithm.newWithBufSize(test.Key, test.BufSize)
+		stream, err := test.Algorithm.streamWithBufSize(test.Key, test.BufSize)
 		if err != nil {
 			t.Fatalf("Test %d: Failed to create new Stream: %v", i, err)
 		}
@@ -200,7 +200,7 @@ func TestSimpleReadFrom(t *testing.T) {
 		ciphertext.Reset()
 		plaintext.Reset()
 
-		stream, err := test.Algorithm.newWithBufSize(test.Key, test.BufSize)
+		stream, err := test.Algorithm.streamWithBufSize(test.Key, test.BufSize)
 		if err != nil {
 			t.Fatalf("Test %d: Failed to create new Stream: %v", i, err)
 		}
@@ -237,7 +237,7 @@ func TestWriteAfterClose(t *testing.T) {
 		w.Write(nil)
 	}
 
-	s, err := AES_128_GCM.New(make([]byte, 16))
+	s, err := AES_128_GCM.Stream(make([]byte, 16))
 	if err != nil {
 		t.Fatalf("Failed to create new Stream: %v", err)
 	}
@@ -262,7 +262,7 @@ func TestWriteByteAfterClose(t *testing.T) {
 		w.WriteByte(0)
 	}
 
-	s, err := AES_128_GCM.New(make([]byte, 16))
+	s, err := AES_128_GCM.Stream(make([]byte, 16))
 	if err != nil {
 		t.Fatalf("Failed to create new Stream: %v", err)
 	}
@@ -286,7 +286,7 @@ func TestReadFromAfterClose(t *testing.T) {
 		w.ReadFrom(bytes.NewReader(nil))
 	}
 
-	s, err := AES_128_GCM.New(make([]byte, 16))
+	s, err := AES_128_GCM.Stream(make([]byte, 16))
 	if err != nil {
 		t.Fatalf("Failed to create new Stream: %v", err)
 	}


### PR DESCRIPTION
#### What does the PR do?
This commit makes the algorithm type
public API by `algorithm` => `Algorithm`.

The idea behind this change is that calling
code can use the `Algorithm` type e.g. in
method calls or struct definitions.
This makes calling code more expressive - e.g.:
`func Encrypt(alg sio.Algorithm, masterKey []byte, kdf KDF) {...}`

Before this change calling code had to pass around
strings and match whether that string value is equal
to one of the algorithm constants defined by sio.

However, the downside of this change is that calling
code now can use "invalid" algorithms - e.g.:
`var myAlgorithm = sio.Algorithm("foo")`

Therefore, `Algorithm.Stream([]byte)` now also returns
an error when the `Algorithm` value is not one of the
defined constants.

So calling code still cannot create or re-define the
implementation of an algorithm. However, it is possible
to construct invalid `Algorithm` values.

Maybe we want to consider a `ParseAlgorithm` or
`AlgorithmFromString` function in `sioutil` to fail
early when reading the `Algorithm` value from a (untrusted)
config / metadata source.

#### What problem does it solve?
<!-- For features and (major) bug fixes link the issue here (e.g. #42) ->




<!-- Thank you very much for contributing to this project! -->
