### PR TITLE
sioutil: add `NativeAES` function

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,4 +2,7 @@ module github.com/secure-io/sio-go
 
 go 1.12
 
-require golang.org/x/crypto v0.0.0-20190513172903-22d7a77e9e5f
+require (
+	golang.org/x/crypto v0.0.0-20190513172903-22d7a77e9e5f
+	golang.org/x/sys v0.0.0-20190412213103-97732733099d
+)

--- a/sioutil/sio.go
+++ b/sioutil/sio.go
@@ -7,6 +7,8 @@ package sioutil
 
 import (
 	"io"
+
+	"golang.org/x/sys/cpu"
 )
 
 type nopCloser struct {
@@ -15,8 +17,35 @@ type nopCloser struct {
 
 func (nopCloser) Close() error { return nil }
 
-// NopCloser returns a WriteCloser with a no-op Close method
-// wrapping the provided Writer w.
+// NopCloser returns a WriteCloser that wraps w
+// and implements Close as a no-op.
 func NopCloser(w io.Writer) io.WriteCloser {
 	return nopCloser{w}
+}
+
+// NativeAES returns true when the executing CPU
+// provides AES-GCM hardware instructions and
+// an optimized assembler implementation is
+// available.
+//
+// It is strongly recommended to only use AES-GCM
+// when NativeAES() returns true. Otherwise, the
+// AES-GCM implementation may be vulnerable to
+// timing attacks.
+// See: https://golang.org/pkg/crypto/aes
+func NativeAES() bool {
+	if cpu.X86.HasAES && cpu.X86.HasPCLMULQDQ {
+		return true
+	}
+	if cpu.ARM64.HasAES {
+		return true
+	}
+
+	// On s390x, aes.NewCipher(...) returns a type
+	// that provides AES asm implementations only
+	// if all (CBC, CTR and GCM) AES hardware
+	// instructions are available.
+	// See: https://golang.org/src/crypto/aes/cipher_s390x.go#L39
+	return cpu.S390X.HasAES && cpu.S390X.HasAESCBC && cpu.S390X.HasAESCTR &&
+		(cpu.S390X.HasAESGCM || cpu.S390X.HasGHASH)
 }


### PR DESCRIPTION


<!-- 
If you want to add a feature or fix a bug (not just typos / code style / ...),
please open an issue first such that we can discuss the feature and track bugs.
See: https://github.com/secure-io/sio-go/issues
Thank you :)
-->

#### What does the PR do?
This commit adds the `NativeAES()` utility function.

As a user of the `sio` package you have to pick an
AEAD algorithm. Usually, AES-GCM gives better performance
if the hardware platform provides AES-specific CPU
instructions and an asm implementation is available.

However, if one of these two conditions is not true,
then AES-GCM may be slower than other AEAD algorithms
(e.g. ChaCha20-Poly1305). Furthermore, generic AES-GCM
is not a constant-time implementation.
See: https://golang.org/pkg/crypto/aes

Therefore, users of `sio` should check whether an asm
implementation is available and whether the CPU provides
AES instructions:
```
if sioutil.NativeAES() {
  // eventually use AES-GCM
} else {
  // eventually use ChaCha20-Poly1305
}
```

#### What problem does it solve?
<!-- For features and (major) bug fixes link the issue here (e.g. #42) ->




<!-- Thank you very much for contributing to this project! -->
