### PR TITLE
fix incorrect ReadFrom benchmarks

### DIFF
--- a/benchmark_test.go
+++ b/benchmark_test.go
@@ -128,6 +128,9 @@ func benchEncryptReadFrom(b *testing.B, s *Stream, size int64) {
 		if _, err := w.ReadFrom(plaintext); err != nil {
 			panic(err)
 		}
+		if err := w.Close(); err != nil {
+			panic(err)
+		}
 
 		w.seqNum = 1
 		w.offset = 0
@@ -146,6 +149,9 @@ func benchDecryptReadFrom(b *testing.B, s *Stream, size int64) {
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		if _, err := w.ReadFrom(plaintext); err != nil {
+			panic(err)
+		}
+		if err := w.Close(); err != nil {
 			panic(err)
 		}
 


### PR DESCRIPTION

<!-- 
If you want to add a feature or fix a bug (not just typos / code style / ...),
please open an issue first such that we can discuss the feature and track bugs.
See: https://github.com/secure-io/sio-go/issues
Thank you :)
-->

#### What does the PR do?
This commit fixes a bug in the `ReadFrom` benchmark implementation
for encryption. The `EncWriter` is not closes such that the last
fragment (resp. the only fragment) gets only copied to the in-memory
buffer but not encrypted nor written to the underlying io.Writer.

This leads to wrong benchmark results - i.e. when the data size
is smaller than the fragment size since we only measure the mem-copy.


#### What problem does it solve?
<!-- For features and (major) bug fixes link the issue here (e.g. #42) ->




<!-- Thank you very much for contributing to this project! -->
