### PR TITLE
add AES-GCM support on ppc64le and bump go version

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,8 @@
 module github.com/secure-io/sio-go
 
-go 1.12
+go 1.13
 
 require (
-	golang.org/x/crypto v0.0.0-20190513172903-22d7a77e9e5f
-	golang.org/x/sys v0.0.0-20190412213103-97732733099d
+	golang.org/x/crypto v0.0.0-20200302210943-78000ba7a073
+	golang.org/x/sys v0.0.0-20200302150141-5c8b2ff67527
 )

--- a/go.sum
+++ b/go.sum
@@ -1,8 +1,9 @@
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
-golang.org/x/crypto v0.0.0-20190513172903-22d7a77e9e5f h1:R423Cnkcp5JABoeemiGEPlt9tHXFfw5kvc0yqlxRPWo=
-golang.org/x/crypto v0.0.0-20190513172903-22d7a77e9e5f/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
+golang.org/x/crypto v0.0.0-20200302210943-78000ba7a073 h1:xMPOj6Pz6UipU1wXLkrtqpHbR0AVFnyPEQq/wRWz9lM=
+golang.org/x/crypto v0.0.0-20200302210943-78000ba7a073/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/net v0.0.0-20190404232315-eb5bcb51f2a3/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=
 golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
-golang.org/x/sys v0.0.0-20190412213103-97732733099d h1:+R4KGOnez64A81RvjARKc4UT5/tI9ujCIVX+P5KiHuI=
 golang.org/x/sys v0.0.0-20190412213103-97732733099d/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20200302150141-5c8b2ff67527 h1:uYVVQ9WP/Ds2ROhcaGPeIdVq0RIXVLwsHlnvJ+cT1So=
+golang.org/x/sys v0.0.0-20200302150141-5c8b2ff67527/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=

--- a/sioutil/aes_generic.go
+++ b/sioutil/aes_generic.go
@@ -1,0 +1,12 @@
+// Copyright (c) 2020 Andreas Auernhammer. All rights reserved.
+// Use of this source code is governed by a license that can be
+// found in the LICENSE file.
+
+// +build !go1.14 !ppc64le
+
+package sioutil
+
+// An asm implementation of AES-GCM for ppc64le is not available
+// before Go 1.14.
+
+const ppcHasAES = false

--- a/sioutil/aes_ppc64le.go
+++ b/sioutil/aes_ppc64le.go
@@ -1,0 +1,12 @@
+// Copyright (c) 2020 Andreas Auernhammer. All rights reserved.
+// Use of this source code is governed by a license that can be
+// found in the LICENSE file.
+
+// +build go1.14,ppc64le
+
+package sioutil
+
+// An asm implementation of AES-GCM for ppc64le is available
+// since Go 1.14.
+
+const ppcHasAES = true

--- a/sioutil/sio.go
+++ b/sioutil/sio.go
@@ -42,6 +42,17 @@ func NativeAES() bool {
 		return true
 	}
 
+	// Go 1.14 introduces an AES-GCM asm implementation
+	// for PPC64le. Therefore, we have to use build tags
+	// to determine whether we're compiling for PPC64 and
+	// use Go 1.14 (or newer).
+	// TODO(aead): Once we drop Go 1.13 support
+	// (bump go version in go.mod) we can remove
+	// pcc64-related build tags again.
+	if ppcHasAES {
+		return true
+	}
+
 	// On s390x, aes.NewCipher(...) returns a type
 	// that provides AES asm implementations only
 	// if all (CBC, CTR and GCM) AES hardware


### PR DESCRIPTION






<!-- 
If you want to add a feature or fix a bug (not just typos / code style / ...),
please open an issue first such that we can discuss the feature and track bugs.
See: https://github.com/secure-io/sio-go/issues
Thank you :)
-->

#### What does the PR do?
This commit adds pcc64le to the list of architectures that
support AES-GCM - but only for Go 1.14 and newer.
Since Go 1.14 there is a asm implementation of AES-GCM.

Further, this commit updates the required dependencies and
bumps the required Go version (from 1.12 to 1.13). We bump the
required Go version since Go only actively supports the latest
two releases. Since Go 1.14 is now available we drop Go 1.12.

#### What problem does it solve?
Fixes #52




<!-- Thank you very much for contributing to this project! -->
