### PR TITLE
Wrap causes in NotAuthentic error

### DIFF
--- a/examples_test.go
+++ b/examples_test.go
@@ -9,6 +9,7 @@ import (
 	"crypto/aes"
 	"crypto/cipher"
 	"encoding/hex"
+	"errors"
 	"fmt"
 	"io"
 	"io/ioutil"
@@ -156,7 +157,7 @@ func ExampleDecReader() {
 
 	// Reading from r returns the original plaintext (or an error).
 	if _, err := ioutil.ReadAll(r); err != nil {
-		if err == sio.NotAuthentic {
+		if errors.Is(err, sio.NotAuthentic) {
 			// Read data is not authentic -> ciphertext has been modified.
 			// TODO: error handling
 			panic(err)
@@ -190,7 +191,7 @@ func ExampleDecReaderAt() {
 
 	// Reading from section returns the original plaintext (or an error).
 	if _, err := ioutil.ReadAll(section); err != nil {
-		if err == sio.NotAuthentic {
+		if errors.Is(err, sio.NotAuthentic) {
 			// Read data is not authentic -> ciphertext has been modified.
 			// TODO: error handling
 			panic(err)
@@ -261,7 +262,7 @@ func ExampleDecWriter() {
 	w := stream.DecryptWriter(plaintext, nonce, associatedData)
 	defer func() {
 		if err := w.Close(); err != nil {
-			if err == sio.NotAuthentic { // During Close() the DecWriter may detect unauthentic data -> decryption error.
+			if errors.Is(err, sio.NotAuthentic) { // During Close() the DecWriter may detect unauthentic data -> decryption error.
 				panic(err) // TODO: error handling
 			}
 			panic(err) // TODO: error handling
@@ -274,7 +275,7 @@ func ExampleDecWriter() {
 	// the underlying io.Writer (i.e. the plaintext *bytes.Buffer) or
 	// returns an error.
 	if _, err := w.Write(ciphertext); err != nil {
-		if err == sio.NotAuthentic {
+		if errors.Is(err, sio.NotAuthentic) {
 			// Read data is not authentic -> ciphertext has been modified.
 			// TODO: error handling
 			panic(err)

--- a/reader.go
+++ b/reader.go
@@ -390,20 +390,20 @@ func (r *DecReader) readFragment(p []byte, firstReadOffset int) (int, error) {
 		if len(p) < r.bufSize {
 			r.plaintextBuffer, err = r.cipher.Open(r.buffer[:0], r.nonce, r.buffer[:ciphertextLen], r.associatedData)
 			if err != nil {
-				r.err = NotAuthentic
+				r.err = sioErrorWithCause(NotAuthentic, err)
 				return 0, r.err
 			}
 			r.offset = copy(p, r.plaintextBuffer)
 			return r.offset, nil
 		}
 		if _, err = r.cipher.Open(p[:0], r.nonce, r.buffer[:ciphertextLen], r.associatedData); err != nil {
-			r.err = NotAuthentic
+			r.err = sioErrorWithCause(NotAuthentic, err)
 			return 0, r.err
 		}
 		return r.bufSize, nil
 	case err == io.EOF:
 		if firstReadOffset+n < r.cipher.Overhead() {
-			r.err = NotAuthentic
+			r.err = sioErrorWithCause(NotAuthentic, err)
 			return 0, r.err
 		}
 		r.closed = true
@@ -411,14 +411,14 @@ func (r *DecReader) readFragment(p []byte, firstReadOffset int) (int, error) {
 		if len(p) < firstReadOffset+n-r.cipher.Overhead() {
 			r.plaintextBuffer, err = r.cipher.Open(r.buffer[:0], r.nonce, r.buffer[:firstReadOffset+n], r.associatedData)
 			if err != nil {
-				r.err = NotAuthentic
+				r.err = sioErrorWithCause(NotAuthentic, err)
 				return 0, r.err
 			}
 			r.offset = copy(p, r.plaintextBuffer)
 			return r.offset, nil
 		}
 		if _, err = r.cipher.Open(p[:0], r.nonce, r.buffer[:firstReadOffset+n], r.associatedData); err != nil {
-			r.err = NotAuthentic
+			r.err = sioErrorWithCause(NotAuthentic, err)
 			return 0, r.err
 
 		}

--- a/writer.go
+++ b/writer.go
@@ -315,7 +315,7 @@ func (w *DecWriter) Write(p []byte) (n int, err error) {
 		}
 		plaintext, err := w.cipher.Open(w.buffer[:0], nonce, w.buffer, w.associatedData)
 		if err != nil {
-			w.err = NotAuthentic
+			w.err = sioErrorWithCause(NotAuthentic, err)
 			return n, w.err
 		}
 		if _, err = writeTo(w.w, plaintext); err != nil {
@@ -332,7 +332,7 @@ func (w *DecWriter) Write(p []byte) (n int, err error) {
 		}
 		plaintext, err := w.cipher.Open(w.buffer[:0], nonce, p[:ciphertextLen], w.associatedData)
 		if err != nil {
-			w.err = NotAuthentic
+			w.err = sioErrorWithCause(NotAuthentic, err)
 			return n, w.err
 		}
 		if _, err = writeTo(w.w, plaintext); err != nil {
@@ -383,7 +383,7 @@ func (w *DecWriter) WriteByte(b byte) error {
 	}
 	plaintext, err := w.cipher.Open(w.buffer[:0], nonce, w.buffer, w.associatedData)
 	if err != nil {
-		w.err = NotAuthentic
+		w.err = sioErrorWithCause(NotAuthentic, err)
 		return w.err
 	}
 	if _, err = writeTo(w.w, plaintext); err != nil {
@@ -418,7 +418,7 @@ func (w *DecWriter) Close() error {
 		binary.LittleEndian.PutUint32(w.nonce[w.cipher.NonceSize()-4:], w.seqNum)
 		plaintext, err := w.cipher.Open(w.buffer[:0], w.nonce, w.buffer[:w.offset], w.associatedData)
 		if err != nil {
-			w.err = NotAuthentic
+			w.err = sioErrorWithCause(NotAuthentic, err)
 			return w.err
 		}
 		if _, w.err = writeTo(w.w, plaintext); w.err != nil {
@@ -479,7 +479,7 @@ func (w *DecWriter) ReadFrom(r io.Reader) (int64, error) {
 	}
 	plaintext, err := w.cipher.Open(buffer[:0], nonce, buffer[:ciphertextLen], w.associatedData)
 	if err != nil {
-		w.err = NotAuthentic
+		w.err = sioErrorWithCause(NotAuthentic, err)
 		return int64(nn), w.err
 	}
 	if _, err = writeTo(w.w, plaintext); err != nil {
@@ -509,7 +509,7 @@ func (w *DecWriter) ReadFrom(r io.Reader) (int64, error) {
 		}
 		plaintext, err = w.cipher.Open(buffer[:0], nonce, buffer[:ciphertextLen], w.associatedData)
 		if err != nil {
-			w.err = NotAuthentic
+			w.err = sioErrorWithCause(NotAuthentic, err)
 			return n, w.err
 		}
 		if _, err = writeTo(w.w, plaintext); err != nil {


### PR DESCRIPTION
This adds error causes to the NotAuthentic error so a client can check
why an operation failed, e.g. because there was a premature io.EOF in
the reader.