### PR TITLE
fix incorrect benchmark Decrypt/WriteTo

### DIFF
--- a/benchmark_test.go
+++ b/benchmark_test.go
@@ -242,7 +242,7 @@ func benchEncryptWriteTo(b *testing.B, s *Stream, size int64) {
 	plaintext := &io.LimitedReader{R: DevNull, N: size}
 
 	r := s.EncryptReader(plaintext, nonce, nil)
-	b.SetBytes(size)
+	b.SetBytes(2*size + s.Overhead(size))
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		if _, err := r.WriteTo(DevNull); err != nil {
@@ -264,7 +264,7 @@ func benchDecryptWriteTo(b *testing.B, s *Stream, size int64) {
 
 	sr := s.EncryptReader(plaintext, nonce, nil)
 	r := s.DecryptReader(sr, nonce, nil)
-	b.SetBytes(size)
+	b.SetBytes(2 * size)
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		if _, err := r.WriteTo(DevNull); err != nil {


### PR DESCRIPTION
<!-- 
If you want to add a feature or fix a bug (not just typos / code style / ...),
please open an issue first such that we can discuss the feature and track bugs.
See: https://github.com/secure-io/sio-go/issues
Thank you :)
-->

#### What does the PR do?
This commit fixes an incorrect benchmark for
Decrypt/WriteTo. The benchmark did both, first
encrypting and than decrypting data. However,
it did only account for one operation.

This lead to confusing benchmark numbers.
This commit fixes this by taking both operations
into account.
