### PR TITLE
pool reader buffers via sync.Pool

### DIFF
--- a/benchmark_test.go
+++ b/benchmark_test.go
@@ -180,11 +180,7 @@ func benchEncryptRead(b *testing.B, s *Stream, size int64) {
 			}
 		}
 
-		r.seqNum = 1
-		r.offset = 0
-		r.closed = false
-		r.firstRead = true
-		r.associatedData[0] = 0
+		r.Reset(0)
 		plaintext.N = size
 	}
 }
@@ -207,11 +203,8 @@ func benchDecryptRead(b *testing.B, s *Stream, size int64) {
 			}
 		}
 
-		r.seqNum, sr.seqNum = 1, 1
-		r.offset, sr.offset = 0, 0
-		r.closed, sr.closed = false, false
-		r.firstRead, sr.firstRead = true, true
-		r.associatedData[0], sr.associatedData[0] = 0, 0
+		sr.Reset(0)
+		r.Reset(0)
 		plaintext.N = size
 	}
 }
@@ -249,11 +242,7 @@ func benchEncryptWriteTo(b *testing.B, s *Stream, size int64) {
 			panic(err)
 		}
 
-		r.seqNum = 1
-		r.offset = 0
-		r.closed = false
-		r.firstRead = true
-		r.associatedData[0] = 0
+		r.Reset(0)
 		plaintext.N = size
 	}
 }
@@ -271,11 +260,8 @@ func benchDecryptWriteTo(b *testing.B, s *Stream, size int64) {
 			panic(err)
 		}
 
-		r.seqNum, sr.seqNum = 1, 1
-		r.offset, sr.offset = 0, 0
-		r.closed, sr.closed = false, false
-		r.firstRead, sr.firstRead = true, true
-		r.associatedData[0], sr.associatedData[0] = 0, 0
+		sr.Reset(0)
+		r.Reset(0)
 		plaintext.N = size
 	}
 }

--- a/pool.go
+++ b/pool.go
@@ -1,0 +1,30 @@
+// Copyright (c) 2019 Andreas Auernhammer. All rights reserved.
+// Use of this source code is governed by a license that can be
+// found in the LICENSE file.
+
+package sio
+
+import "sync"
+
+var bufPools = map[int]*sync.Pool{
+	BufSize + 16 + 1:  {New: func() any { b := make([]byte, BufSize+16+1); return &b }},
+	128*1024 + 16 + 1: {New: func() any { b := make([]byte, 128*1024+16+1); return &b }},
+}
+
+func alloc(size int) *[]byte {
+	if pool, ok := bufPools[size]; ok {
+		return pool.Get().(*[]byte)
+	}
+	b := make([]byte, size)
+	return &b
+}
+
+func free(p *[]byte) {
+	if p == nil {
+		return
+	}
+	if pool, ok := bufPools[len(*p)]; ok {
+		clear(*p)
+		pool.Put(p)
+	}
+}

--- a/reader.go
+++ b/reader.go
@@ -10,6 +10,7 @@ import (
 	"io"
 	"math"
 	"sync"
+	"sync/atomic"
 )
 
 // An EncReader encrypts and authenticates everything it reads
@@ -23,6 +24,7 @@ type EncReader struct {
 	nonce          []byte
 	associatedData []byte
 
+	ptr              atomic.Pointer[[]byte]
 	buffer           []byte
 	ciphertextBuffer []byte
 	offset           int
@@ -55,7 +57,12 @@ func (r *EncReader) Reset(blockNum uint32) {
 	binary.LittleEndian.PutUint32(r.nonce[len(r.nonce)-4:], 0)
 	r.associatedData[0] = 0x00
 
+	if r.ptr.Load() == nil {
+		r.ptr.Store(alloc(1 + r.bufSize + r.cipher.Overhead()))
+	}
+	r.buffer = *r.ptr.Load()
 	clear(r.buffer)
+	r.ciphertextBuffer = nil
 	r.offset = 0
 
 	r.carry, r.err = 0, nil
@@ -71,6 +78,13 @@ func (r *EncReader) Reset(blockNum uint32) {
 // When Read cannot encrypt any more bytes securely it returns
 // ErrExceeded.
 func (r *EncReader) Read(p []byte) (n int, err error) {
+	if n, err = r.read(p); err != nil {
+		r.free()
+	}
+	return n, err
+}
+
+func (r *EncReader) read(p []byte) (n int, err error) {
 	if r.err != nil {
 		return n, r.err
 	}
@@ -106,6 +120,14 @@ func (r *EncReader) Read(p []byte) (n int, err error) {
 // When ReadByte cannot encrypt one more byte
 // securely it returns ErrExceeded.
 func (r *EncReader) ReadByte() (byte, error) {
+	b, err := r.readByte()
+	if err != nil {
+		r.free()
+	}
+	return b, err
+}
+
+func (r *EncReader) readByte() (byte, error) {
 	if r.err != nil {
 		return 0, r.err
 	}
@@ -145,6 +167,7 @@ func (r *EncReader) ReadByte() (byte, error) {
 // securely it returns ErrExceeded.
 func (r *EncReader) WriteTo(w io.Writer) (int64, error) {
 	var n int64
+	defer r.free()
 	if r.firstRead {
 		r.firstRead = false
 		nn, err := r.readFragment(r.buffer, 0)
@@ -228,6 +251,13 @@ func (r *EncReader) readFragment(p []byte, firstReadOffset int) (int, error) {
 	}
 }
 
+func (r *EncReader) free() {
+	if ptr := r.ptr.Load(); ptr != nil && r.ptr.CompareAndSwap(ptr, nil) {
+		free(ptr)
+		r.buffer, r.ciphertextBuffer = nil, nil
+	}
+}
+
 // A DecReader decrypts and verifies everything it reads
 // from an underlying io.Reader. A DecReader never returns
 // invalid (i.e. not authentic) data.
@@ -240,6 +270,7 @@ type DecReader struct {
 	nonce          []byte
 	associatedData []byte
 
+	ptr             atomic.Pointer[[]byte]
 	buffer          []byte
 	plaintextBuffer []byte
 	offset          int
@@ -267,7 +298,12 @@ func (r *DecReader) Reset(blockNum uint32) {
 	binary.LittleEndian.PutUint32(r.nonce[len(r.nonce)-4:], 0)
 	r.associatedData[0] = 0x00
 
+	if r.ptr.Load() == nil {
+		r.ptr.Store(alloc(1 + r.bufSize + r.cipher.Overhead()))
+	}
+	r.buffer = *r.ptr.Load()
 	clear(r.buffer)
+	r.plaintextBuffer = nil
 	r.offset = 0
 
 	r.carry, r.err = 0, nil
@@ -290,6 +326,13 @@ func (r *DecReader) Reset(blockNum uint32) {
 // encrypted bytes. Therefore, ErrExceeded indicates
 // a misbehaving producer of encrypted data.
 func (r *DecReader) Read(p []byte) (n int, err error) {
+	if n, err = r.read(p); err != nil {
+		r.free()
+	}
+	return n, err
+}
+
+func (r *DecReader) read(p []byte) (n int, err error) {
 	if r.err != nil {
 		return n, r.err
 	}
@@ -333,6 +376,14 @@ func (r *DecReader) Read(p []byte) (n int, err error) {
 // many encrypted bytes. Therefore, ErrExceeded indicates
 // a misbehaving producer of encrypted data.
 func (r *DecReader) ReadByte() (byte, error) {
+	b, err := r.readByte()
+	if err != nil {
+		r.free()
+	}
+	return b, err
+}
+
+func (r *DecReader) readByte() (byte, error) {
 	if r.err != nil {
 		return 0, r.err
 	}
@@ -382,6 +433,8 @@ func (r *DecReader) WriteTo(w io.Writer) (int64, error) {
 	if r.err != nil {
 		return n, r.err
 	}
+
+	defer r.free()
 	if r.firstRead {
 		r.firstRead = false
 		nn, err := r.readFragment(r.buffer, 0)
@@ -480,6 +533,13 @@ func (r *DecReader) readFragment(p []byte, firstReadOffset int) (int, error) {
 	case err != nil:
 		r.err = err
 		return 0, r.err
+	}
+}
+
+func (r *DecReader) free() {
+	if ptr := r.ptr.Load(); ptr != nil && r.ptr.CompareAndSwap(ptr, nil) {
+		free(ptr)
+		r.buffer, r.plaintextBuffer = nil, nil
 	}
 }
 

--- a/sio.go
+++ b/sio.go
@@ -267,9 +267,11 @@ func (s *Stream) EncryptReader(r io.Reader, nonce, associatedData []byte) *EncRe
 		seqNum:         1,
 		nonce:          make([]byte, s.cipher.NonceSize()),
 		associatedData: make([]byte, 1+s.cipher.Overhead()),
-		buffer:         make([]byte, 1+s.bufSize+s.cipher.Overhead()),
 		firstRead:      true,
 	}
+	er.ptr.Store(alloc(1 + s.bufSize + s.cipher.Overhead()))
+	er.buffer = *(er.ptr.Load())
+
 	copy(er.nonce, nonce)
 	er.associatedData[0] = 0x00
 	binary.LittleEndian.PutUint32(er.nonce[er.cipher.NonceSize()-4:], 0)
@@ -289,6 +291,7 @@ func (s *Stream) DecryptReader(r io.Reader, nonce, associatedData []byte) *DecRe
 	if len(nonce) != s.NonceSize() {
 		panic("sio: nonce has invalid length")
 	}
+
 	dr := &DecReader{
 		r:              r,
 		cipher:         s.cipher,
@@ -296,9 +299,11 @@ func (s *Stream) DecryptReader(r io.Reader, nonce, associatedData []byte) *DecRe
 		seqNum:         1,
 		nonce:          make([]byte, s.cipher.NonceSize()),
 		associatedData: make([]byte, 1+s.cipher.Overhead()),
-		buffer:         make([]byte, 1+s.bufSize+s.cipher.Overhead()),
 		firstRead:      true,
 	}
+	dr.ptr.Store(alloc(1 + s.bufSize + s.cipher.Overhead()))
+	dr.buffer = *(dr.ptr.Load())
+
 	copy(dr.nonce, nonce)
 	dr.associatedData[0] = 0x00
 	binary.LittleEndian.PutUint32(dr.nonce[dr.cipher.NonceSize()-4:], 0)
@@ -332,7 +337,7 @@ func (s *Stream) DecryptReaderAt(r io.ReaderAt, nonce, associatedData []byte) *D
 
 	bufLen := 1 + dr.bufSize + dr.cipher.Overhead()
 	dr.bufPool = sync.Pool{
-		New: func() interface{} {
+		New: func() any {
 			b := make([]byte, bufLen)
 			return &b
 		},


### PR DESCRIPTION
Add a pool.go that maintains sync.Pools keyed by buffer size for the common BufSize and 128 KiB block sizes, with alloc/free helpers that fall back to plain make() for non-pooled sizes.

EncReader and DecReader now draw their working buffer from the pool instead of allocating it directly, and return it once the stream is exhausted. Each reader guards the buffer with an atomic.Pointer so free() releases it exactly once: Read/ReadByte free on error (including io.EOF), and WriteTo frees via defer. Reset re-acquires a buffer if it was previously freed.

Also switch the benchmark resets to use Reset(0) instead of poking at internal fields, and replace interface{} with any in DecReaderAt.
